### PR TITLE
Swift 2 migration

### DIFF
--- a/Faker.podspec
+++ b/Faker.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/kleiram/faker.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/kleiram'
 
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'Source/**/*.swift'
 end

--- a/Faker.xcodeproj/project.pbxproj
+++ b/Faker.xcodeproj/project.pbxproj
@@ -484,6 +484,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.apostle.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -502,6 +503,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.apostle.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ with more Swift specific code (not a direct port).
 
 ## Requirements
 
- - iOS 9.0+
+ - iOS 8.0+
 
 ## Installation
 
@@ -23,7 +23,7 @@ To integrate Faker into your Xcode project using CocoaPods, specify it in your `
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '8.0'
 use_frameworks!
 
 pod 'Faker'

--- a/Source/Classes/Internet.swift
+++ b/Source/Classes/Internet.swift
@@ -166,7 +166,7 @@ public class Internet {
                    `maxLength` characters.
     */
     public class func password(minLength : Int = 6, maxLength : Int = 20) -> String {
-        let format = "".join(Array(count: Int.random(minLength, max: maxLength), repeatedValue: "*"))
+        let format = Array(count: Int.random(minLength, max: maxLength), repeatedValue: "*").joinWithSeparator("")
         
         return format.lexify()
     }
@@ -221,7 +221,7 @@ public class Internet {
             return ""
         }
         
-        return "-".join(Lorem.words(variable ? nbWords.randomize(40) : nbWords)).lowercaseString
+        return Lorem.words(variable ? nbWords.randomize(40) : nbWords).joinWithSeparator("-").lowercaseString
     }
     
     /**
@@ -230,12 +230,12 @@ public class Internet {
         - returns: Returns a random IPv4 address.
     */
     public class func ipv4() -> String {
-        return ".".join([
+        return [
             Int.random(0, max: 255),
             Int.random(0, max: 255),
             Int.random(0, max: 255),
             Int.random(0, max: 255)
-        ].map(String.init))
+        ].map(String.init).joinWithSeparator(".")
     }
     
     /**
@@ -246,7 +246,7 @@ public class Internet {
     public class func ipv6() -> String {
         let components = (0..<8).map { _ in Int.random(0, max: 65535) }
         
-        return ":".join(components.map({ String(format: "%04x", arguments: [ $0 ]) }))
+        return components.map({ String(format: "%04x", arguments: [ $0 ]) }).joinWithSeparator(":")
     }
     
     /**
@@ -266,7 +266,7 @@ public class Internet {
             components = (0..<2).map({ _ in Int.random(0, max: 255) }).map(String.init)
         }
         
-        return prefix + ".".join(components)
+        return prefix + components.joinWithSeparator(".")
     }
     
     /**
@@ -277,7 +277,7 @@ public class Internet {
     public class func mac() -> String {
         let components = (0..<6).map { _ in Int.random(0, max: 255) }
         
-        return ":".join(components.map({ String(format: "%02X", arguments: [ $0 ]) }))
+        return components.map({ String(format: "%02X", arguments: [ $0 ]) }).joinWithSeparator(":")
     }
     
     private class func dataProvider() -> Provider {

--- a/Source/Classes/Lorem.swift
+++ b/Source/Classes/Lorem.swift
@@ -91,7 +91,7 @@ public class Lorem {
         - returns: Returns a string of `count` words.
     */
     public class func words(count : Int = 3) -> String {
-        return " ".join(words(count))
+        return words(count).joinWithSeparator(" ")
     }
     
     /**
@@ -132,7 +132,7 @@ public class Lorem {
         - returns: Returns a string of random sentences.
     */
     public class func sentences(nbSentences : Int = 3) -> String {
-        return " ".join(sentences(nbSentences))
+        return sentences(nbSentences).joinWithSeparator(" ")
     }
     
     /**
@@ -150,7 +150,7 @@ public class Lorem {
             return ""
         }
         
-        return " ".join(sentences(variable ? nbSentences.randomize(40) : nbSentences))
+        return sentences(variable ? nbSentences.randomize(40) : nbSentences).joinWithSeparator(" ")
     }
     
     /**
@@ -172,7 +172,7 @@ public class Lorem {
         - returns: Returns a string of random paragraphs.
     */
     public class func paragraphs(nbParagraphs : Int = 3) -> String {
-        return "\n\n".join(paragraphs(nbParagraphs))
+        return paragraphs(nbParagraphs).joinWithSeparator("\n\n")
     }
     
     /**
@@ -226,7 +226,7 @@ public class Lorem {
             }
         }
         
-        return "".join(result)
+        return result.joinWithSeparator("")
     }
 }
 

--- a/Source/Extensions/String.swift
+++ b/Source/Extensions/String.swift
@@ -45,13 +45,13 @@ public extension String {
                    with numbers between `[0,9]` and `[1,9]` respectively.
      */
     public func numerify() -> String {
-        return "".join(characters.map {
+        return characters.map {
             switch $0 {
             case "#": return String(Int.random(0, max: 9))
             case "%": return String(Int.random(1, max: 9))
             default:  return String($0)
             }
-        })
+        }.joinWithSeparator("")
     }
     
     /**
@@ -65,13 +65,13 @@ public extension String {
                    character respectively.
     */
     public func lexify() -> String {
-        return "".join(characters.map {
+        return characters.map {
             switch $0 {
             case "?": return String(Character.randomLetter())
             case "*": return String(Character.randomAscii())
             default:  return String($0)
             }
-        })
+        }.joinWithSeparator("")
     }
     
     /**


### PR DESCRIPTION
Replaced instances of `join` with `joinWithSeparator` for Swift 2 compatibility. No other changes were necessary.
